### PR TITLE
support comic archives like cbz

### DIFF
--- a/src/pwa/src/helper.ts
+++ b/src/pwa/src/helper.ts
@@ -1,7 +1,14 @@
 export const imgExtension = new Set(['.png', '.gif', '.jpeg', '.jpg', '.webp']);
 
-export type ZipExtension = '.zip' | '.rar' | '.7z';
-export const zipExtension = new Set<ZipExtension>(['.zip', '.rar', '.7z']);
+export type ZipExtension = '.zip' | '.rar' | '.7z' | '.cbz' | '.cbr' | '.cb7';
+export const zipExtension = new Set<ZipExtension>([
+  '.zip',
+  '.rar',
+  '.7z',
+  '.cbz',
+  '.cbr',
+  '.cb7',
+]);
 
 const extensionRe = /\.[^.]+$/;
 /** 根据文件名判断文件是否受支持 */

--- a/src/pwa/src/index.tsx
+++ b/src/pwa/src/index.tsx
@@ -28,9 +28,9 @@ const handleSelectFiles = async () =>
           description: 'Images',
           accept: {
             'image/*': [...imgExtension.values()],
-            'application/zip': '.zip',
-            'application/x-rar-compressed': '.rar',
-            'application/x-7z-compressed': '.7z',
+            'application/zip': ['.zip', '.cbz'],
+            'application/x-rar-compressed': ['.rar', '.cbr'],
+            'application/x-7z-compressed': ['.7z', '.cb7'],
           },
         },
       ],

--- a/src/pwa/src/unzip/fflate.ts
+++ b/src/pwa/src/unzip/fflate.ts
@@ -12,7 +12,7 @@ const fflateUnzip = (data: Uint8Array, opts: AsyncUnzipOptions) =>
 
 /** 解压缩 zip，速度超快 */
 export const fflate = async ({ zipFile, extension }: ZipData) => {
-  if (extension !== '.zip') return [];
+  if (extension !== '.zip' && extension !== '.cbz') return [];
 
   try {
     const fileData = await zipFile

--- a/src/pwa/src/unzip/libunrar.ts
+++ b/src/pwa/src/unzip/libunrar.ts
@@ -77,7 +77,7 @@ export const libunrar = async (
   password?: string,
 ): Promise<Array<ImgFile | undefined>> => {
   const { zipFile, tip, extension } = zipData;
-  if (extension !== '.rar') return [];
+  if (extension !== '.rar' && extension !== '.cbr') return [];
   if (!rpc) {
     await waitRPC();
     rpc = await RPC.new('./libunrar/worker.js');


### PR DESCRIPTION
`.cbz`s are frequently used for archives of comic images in compressed format. This PR recognizes the `cbz`, `cbr` and `cb7` file extensions.