### PR TITLE
feat: add file association for comic archives

### DIFF
--- a/src/pwa/vite.config.ts
+++ b/src/pwa/vite.config.ts
@@ -48,9 +48,9 @@ const manifest: Partial<ManifestOptions> = {
     {
       action: '/',
       accept: {
-        'application/zip': ['.zip'],
-        'application/x-rar-compressed': ['.rar'],
-        'application/x-7z-compressed': ['.7z'],
+        'application/zip': ['.zip', '.cbz'],
+        'application/x-rar-compressed': ['.rar', '.cbr'],
+        'application/x-7z-compressed': ['.7z', '.cb7'],
       },
     },
   ],


### PR DESCRIPTION
为 PWA 添加 `.cbz`, `.cbr`, `.cb7` 的文件关联。