### PR TITLE
[fix] #211简易适配新版本manga-image-translator

### DIFF
--- a/src/components/Manga/actions/translation/helper.ts
+++ b/src/components/Manga/actions/translation/helper.ts
@@ -52,7 +52,7 @@ export const createFormData = (
     formData.append('image', file);
     formData.append('config', JSON.stringify({
       detector: {
-        detector: 'default',
+        detector: detector,
         detection_size: SizeLists.find((item) => item[0] === size)?.[1] ?? 0,
       },
       render: {

--- a/src/components/Manga/actions/translation/helper.ts
+++ b/src/components/Manga/actions/translation/helper.ts
@@ -37,17 +37,34 @@ export const createFormData = (
   });
   const { size, detector, direction, translator, targetLanguage } =
     store.option.translation.options;
-
+  let SizeLists = [['S', 1024], ['M', 1536], ['L', 2048], ['X', 2560]]
   const formData = new FormData();
-  formData.append('file', file);
-  formData.append('mime', file.type);
-  formData.append('size', size);
-  formData.append('detector', detector);
-  formData.append('direction', direction);
-  formData.append('translator', translator);
-  if (type === 'cotrans') formData.append('target_language', targetLanguage);
-  else formData.append('target_lang', targetLanguage);
-  formData.append('retry', `${store.option.translation.forceRetry}`);
+  if (type === 'cotrans') {
+    formData.append('file', file);
+    formData.append('mime', file.type);
+    formData.append('size', size);
+    formData.append('detector', detector);
+    formData.append('direction', direction);
+    formData.append('translator', translator);
+    formData.append('target_language', targetLanguage);
+    formData.append('retry', `${store.option.translation.forceRetry}`);
+  }else if (type === 'selfhosted') {
+    formData.append('image', file);
+    formData.append('config', JSON.stringify({
+      detector: {
+        detector: 'default',
+        detection_size: SizeLists.find((item) => item[0] === size)?.[1] ?? 0,
+      },
+      render: {
+        direction: direction,
+      },
+      translator: {
+        translator: translator,
+        target_lang: targetLanguage,
+      }
+    }));
+
+  }
   return formData;
 };
 


### PR DESCRIPTION
改PR仍存在以下问题：
1. 任务执行不是异步的（新版本的MangaImgTrans去掉了原有的`submit`异步执行方式，只能使用流式或非流式的任务执行）
2. 没有足够恰当的异常捕获，仍需要适当修改后才能并入

#211

ps：最新版本manga-image-translator本身可能存在部分问题，相关问题和PR与ComicRead无关，已提交至manga trans。
ps2：有关manga-image-translator的问题已合并，目前与该脚本匹配良好。