### PR TITLE
Fix dm5 by adding cnc.dm5.com

### DIFF
--- a/ComicRead-AdGuard.user.js
+++ b/ComicRead-AdGuard.user.js
@@ -13354,6 +13354,7 @@ const helper = require('helper');
     case 'www.1kkk.com':
     case 'tel.dm5.com':
     case 'en.dm5.com':
+    case 'cnc.dm5.com':
     case 'www.dm5.cn':
     case 'www.dm5.com':
       {

--- a/ComicRead.user.js
+++ b/ComicRead.user.js
@@ -13277,6 +13277,7 @@ const helper = require('helper');
     case 'www.1kkk.com':
     case 'tel.dm5.com':
     case 'en.dm5.com':
+    case 'cnc.dm5.com':
     case 'www.dm5.cn':
     case 'www.dm5.com':
       {

--- a/src/index.ts
+++ b/src/index.ts
@@ -424,6 +424,7 @@ try {
     case 'www.1kkk.com':
     case 'tel.dm5.com':
     case 'en.dm5.com':
+    case 'cnc.dm5.com':
     case 'www.dm5.cn':
     case 'www.dm5.com': {
       if (!Reflect.has(unsafeWindow, 'DM5_CID')) break;


### PR DESCRIPTION
dm5.com 现在的漫画页网址形如：https://cnc.dm5.com/m1640565/ ，漫画详情页 https://cnc.dm5.com/manhua-liulilonglong/ ，无法正确激活插件。增加匹配 "cnc.dm5.com"