### PR TITLE
解决使用自定义翻译URL为ngrok时，需要验证警告页面的问题

### DIFF
--- a/ComicRead.user.js
+++ b/ComicRead.user.js
@@ -2872,9 +2872,11 @@ const selfhostedTranslation = async url => {
     }
     return URL.createObjectURL(await downloadImg(\`\${apiUrl()}/result/\${task_id}\`));
   }
+  const headers_ngrok = apiUrl().includes('ngrok-free')? new Headers({ "ngrok-skip-browser-warning": "69420" }) : undefined;
   try {
     const res = await fetch(\`\${apiUrl()}/translate/with-form/image/stream\`, {
       method: 'POST',
+      headers_ngrok,
       body: createFormData(imgBlob, 'selfhosted')
     });
     if (res.status !== 200 || !res.body) throw new Error(helper.t('translation.status.error'));
@@ -2931,6 +2933,7 @@ const selfhostedTranslation = async url => {
       // 也找不到第二个同样问题的网站，考虑到应该没人会在拷贝上翻译，就暂且不管了
       const res = await request.request(\`\${apiUrl()}/translate/with-form/image\`, {
         method: 'POST',
+        headers_ngrok,
         responseType: 'blob',
         fetch: false,
         timeout: 1000 * 60 * 10,


### PR DESCRIPTION
Scope: 自定义翻译 URL


**背景**

在 Kaggle 等平台使用免费 GPU 运行翻译程序时，需要通过 ngrok 等内网穿透工具暴露服务。但 ngrok 免费用户每次访问都会遇到警告页面，未通过验证会导致翻译功能请求失败。

其实通常在浏览器中手动访问一次警告页面即可正常使用翻译功能了，但我昨晚发现，在 PWA 环境下是无法打开该页面进行验证的TAT

**解决方案**

当检测到 ngrok 域名时，自动添加 `ngrok-skip-browser-warning` 请求头以跳过警告页面。