### PR TITLE
解决使用自定义翻译URL为ngrok时，需要验证警告页面的问题

### DIFF
--- a/src/components/Manga/actions/translation/selfhosted.ts
+++ b/src/components/Manga/actions/translation/selfhosted.ts
@@ -87,9 +87,11 @@ export const selfhostedTranslation = async (url: string): Promise<string> => {
     );
   }
 
+  const headers_ngrok = apiUrl().includes('ngrok-free')? new Headers({ "ngrok-skip-browser-warning": "69420" }) : undefined;
   try {
     const res = await fetch(`${apiUrl()}/translate/with-form/image/stream`, {
       method: 'POST',
+      headers: headers_ngrok,
       body: createFormData(imgBlob, 'selfhosted'),
     });
 
@@ -147,6 +149,7 @@ export const selfhostedTranslation = async (url: string): Promise<string> => {
         responseType: 'blob',
         fetch: false,
         timeout: 1000 * 60 * 10,
+        headers: headers_ngrok,
         data: createFormData(imgBlob, 'selfhosted'),
         errorText: t('translation.tip.upload_error'),
       });


### PR DESCRIPTION
Scope: src/components/Manga/actions/translation/selfhosted.ts 
自定义翻译 URL


**背景**

在 Kaggle 等平台使用免费 GPU 运行翻译程序时，需要通过 ngrok 等内网穿透工具暴露服务。但 ngrok 免费用户每次访问都会遇到警告页面，未通过验证会导致翻译功能请求失败。

其实通常在浏览器中手动访问一次警告页面即可正常使用翻译功能了，但我昨晚发现，在 PWA 环境下是无法打开该页面进行验证的TAT

**解决方案**

当检测到 ngrok 域名时，自动添加 `ngrok-skip-browser-warning` 请求头以跳过警告页面。




